### PR TITLE
Add TypeScript support for webworkers

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,6 +5,7 @@
             "dom",
             "es2016",
             "esnext.asynciterable",
+            "webworker",
         ],
         "typeRoots": [
             "node_modules/@types",


### PR DESCRIPTION
I needed this to compile `service-worker` with TypeScript

Without it I get:
> @rollup/plugin-typescript TS2339: Property 'waitUntil' does not exist on type 'Event'.