### PR TITLE
Remove unnecessary TypeScript config

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,10 +6,6 @@
             "es2016",
             "esnext.asynciterable",
         ],
-        "typeRoots": [
-            "node_modules/@types",
-        ],
-        "types": [],
         "allowSyntheticDefaultImports": true,
         "alwaysStrict": true,
         "experimentalDecorators": true,


### PR DESCRIPTION
This is the default:
```
        "typeRoots": [
            "node_modules/@types",
        ],
```

And I believe this tells it to ignore all types:
```
        "types": [],
```