### PR TITLE
 🐛 fix: workaround Sapper's warning-swallowing issue until it's solved upstream

### DIFF
--- a/rollup.config.js
+++ b/rollup.config.js
@@ -23,7 +23,8 @@ const warningIsIgnored = (warning) => warning.message.includes(
 	"Use of eval is strongly discouraged, as it poses security risks and may cause issues with minification",
 ) || warning.message.includes("Circular dependency: node_modules");
 
-const onwarn = (warning, onwarn_) => (warning.code === "CIRCULAR_DEPENDENCY" && /[/\\]@sapper[/\\]/.test(warning.message)) || warningIsIgnored(warning) || onwarn_(warning);
+// Workaround for https://github.com/sveltejs/sapper/issues/1221
+const onwarn = (warning, _onwarn) => (warning.code === "CIRCULAR_DEPENDENCY" && /[/\\]@sapper[/\\]/.test(warning.message)) || warningIsIgnored(warning) || console.warn(warning.toString());
 
 export default {
 	client: {


### PR DESCRIPTION
I've had to deal with https://github.com/sveltejs/sapper/issues/1221 before, and I'll forget about this being the reason if we don't solve it explicitly now. Let's make this the last time gets frustrated with this error (provided they use this template or its derivative).

How's this approach @benmccann? Probably going to merge it in the evening if there aren't any cases it misses. 