### PR TITLE
[types] Add noscroll option to goto

### DIFF
--- a/types/@sapper/index.d.ts
+++ b/types/@sapper/index.d.ts
@@ -9,7 +9,7 @@ declare module "@sapper/app" {
 		location: string
 	}
 
-	function goto(href: string, opts: { replaceState: boolean }): Promise<unknown>
+	function goto(href: string, opts: { replaceState: boolean, noscroll: boolean }): Promise<unknown>
 	function prefetch(href: string): Promise<{ redirect?: Redirect; data?: unknown }>
 	function prefetchRoutes(pathnames: string[]): Promise<unknown>
 	function start(opts: { target: Node }): Promise<unknown>


### PR DESCRIPTION
A `noscroll` option was added to `goto` in the latest Sapper release (https://github.com/sveltejs/sapper/pull/1320)